### PR TITLE
ユーザーフォロー機能実装

### DIFF
--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -10,7 +10,6 @@ class BooksController < ApplicationController
 
   # GET /books/1
   def show
-    current_user.books.find(params[:id])
   end
 
   # GET /books/new

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -5,7 +5,7 @@ class BooksController < ApplicationController
 
   # GET /books
   def index
-    @books = Book.page(params[:page])
+    @books = Book.where(user_id: current_user.following).or(Book.where(user_id: current_user)).page(params[:page])
   end
 
   # GET /books/1

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -10,6 +10,7 @@ class BooksController < ApplicationController
 
   # GET /books/1
   def show
+    current_user.books.find(params[:id])
   end
 
   # GET /books/new
@@ -19,11 +20,12 @@ class BooksController < ApplicationController
 
   # GET /books/1/edit
   def edit
+    current_user.books.find(params[:id])
   end
 
   # POST /books
   def create
-    @book = Book.new(book_params)
+    @book = current_user.books.new(book_params)
     if @book.save
       redirect_to @book, notice: t("flash.create")
     else
@@ -33,7 +35,8 @@ class BooksController < ApplicationController
 
   # PATCH/PUT /books/1
   def update
-    if @book.update(book_params)
+    if @book = current_user.books.find(params[:id])
+      @book.update(book_params)
       redirect_to @book, notice: t("flash.update")
     else
       render :edit
@@ -42,6 +45,7 @@ class BooksController < ApplicationController
 
   # DELETE /books/1
   def destroy
+    @book = current_user.books.find(params[:id])
     @book.destroy
     redirect_to books_url, notice: t("flash.destroy")
   end

--- a/app/controllers/follows_controller.rb
+++ b/app/controllers/follows_controller.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class FollowsController < ApplicationController
+  before_action :authenticate_user!
+
+  def create
+    @user = User.find(params[:followed_id])
+    current_user.follow(@user)
+    redirect_to @user
+  end
+
+  def destroy
+    @user = Follow.find(params[:id]).followed
+    current_user.unfollow(@user)
+    redirect_to @user
+  end
+end

--- a/app/controllers/users/followers_controller.rb
+++ b/app/controllers/users/followers_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Users::FollowersController < ApplicationController
+  before_action :authenticate_user!, only: [:index]
+
+  def index
+    @user = User.find(params[:user_id])
+    @users = @user.followers
+  end
+end

--- a/app/controllers/users/followers_controller.rb
+++ b/app/controllers/users/followers_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Users::FollowersController < ApplicationController
-  before_action :authenticate_user!, only: [:index]
-
   def index
     @user = User.find(params[:user_id])
     @users = @user.followers

--- a/app/controllers/users/followings_controller.rb
+++ b/app/controllers/users/followings_controller.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+class Users::FollowingsController < ApplicationController
+  before_action :authenticate_user!, only: [:index]
+
+  def index
+    @user = User.find(params[:user_id])
+    @users = @user.following
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
+  def index
+    @users = User.all
+  end
+
   def show
     @user = User.find(params[:id])
   end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,4 +2,5 @@
 
 class Book < ApplicationRecord
   mount_uploader :picture, PictureUploader
+  belongs_to :user
 end

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -1,4 +1,8 @@
 # frozen_string_literal: true
 
 class Follow < ApplicationRecord
+  belongs_to :follower, class_name: "User"
+  belongs_to :followed, class_name: "User"
+  validates :follower_id, presence: true
+  validates :followed_id, presence: true
 end

--- a/app/models/follow.rb
+++ b/app/models/follow.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class Follow < ApplicationRecord
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,8 +1,7 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
+  has_many :books
   has_one_attached :avatar
   devise :database_authenticatable, :registerable, :recoverable,
          :rememberable, :validatable, :omniauthable, omniauth_providers: %i[github]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
-  has_many :books
+  has_many :books, dependent: :destroy
   has_one_attached :avatar
   devise :database_authenticatable, :registerable, :recoverable,
          :rememberable, :validatable, :omniauthable, omniauth_providers: %i[github]

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -41,6 +41,19 @@ class User < ApplicationRecord
     update_attributes(params, *options)
   end
 
+  def follow(other_user)
+    following << other_user
+  end
+
+  def unfollow(other_user)
+    active_follows.find_by(followed_id: other_user.id).destroy
+  end
+
+  # 現在のユーザーがフォローしてたらtrueを返す
+  def following?(other_user)
+    following.include?(other_user)
+  end
+
   private
     def self.dummy_email(auth)
       "#{auth.uid}-#{auth.provider}@example.com"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,9 +2,20 @@
 
 class User < ApplicationRecord
   has_many :books, dependent: :destroy
+
+  has_many :active_follows, class_name: "Follow",
+            foreign_key: "follower_id",
+            dependent: :destroy
+  has_many :passive_follows, class_name: "Follow",
+            foreign_key: "followed_id",
+            dependent: :destroy
+  has_many :following, through: :active_follows, source: :followed
+  has_many :followers, through: :passive_follows, source: :follower
+
   has_one_attached :avatar
+
   devise :database_authenticatable, :registerable, :recoverable,
-         :rememberable, :validatable, :omniauthable, omniauth_providers: %i[github]
+          :rememberable, :validatable, :omniauthable, omniauth_providers: %i[github]
 
   def self.find_for_github_oauth(auth, signed_in_resource = nil)
     where(provider: auth.provider, uid: auth.uid).first_or_create do |user|

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -5,6 +5,7 @@
 <table>
   <thead>
     <tr>
+      <th><%= Book.human_attribute_name(:user_name) %></th>
       <th><%= Book.human_attribute_name(:title) %></th>
       <th><%= Book.human_attribute_name(:memo) %></th>
       <th><%= Book.human_attribute_name(:picture) %></th>
@@ -15,6 +16,7 @@
   <tbody>
     <% @books.each do |book| %>
       <tr>
+        <td><%= link_to book.user.name, user_path(id: book.user_id) %></td>
         <td><%= book.title %></td>
         <td><%= book.memo %></td>
         <td><%= book.picture %></td>

--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -19,8 +19,10 @@
         <td><%= book.memo %></td>
         <td><%= book.picture %></td>
         <td><%= link_to t("link.Show"), book %></td>
-        <td><%= link_to t("link.Edit"), edit_book_path(book) %></td>
-        <td><%= link_to t("link.Destroy"), book, method: :delete, data: { confirm: t("alert.sure") } %></td>
+        <% if book.user_id == current_user.id %>
+          <td><%= link_to t("link.Edit"), edit_book_path(book) %></td>
+          <td><%= link_to t("link.Destroy"), book, method: :delete, data: { confirm: t("alert.sure") } %></td>
+        <% end %>
       </tr>
     <% end %>
   </tbody>

--- a/app/views/books/show.html.erb
+++ b/app/views/books/show.html.erb
@@ -13,6 +13,7 @@
   <strong><%= Book.human_attribute_name(:picture) %>:</strong>
   <%= image_tag(@book.picture_url) if @book.picture.present? %>
 </p>
-
-<%= link_to t("link.Edit"), edit_book_path(@book) %> |
+<% if @book.user_id == current_user.id %>
+  <%= link_to t("link.Edit"), edit_book_path(@book) %> |
+<% end %>
 <%= link_to t("link.Back"), books_path %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -31,6 +31,4 @@
   </div>
 <% end %>
 
-<%= link_to 'Githubでログイン', user_github_omniauth_authorize_path %>
-
 <%= render "devise/shared/links" %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -14,11 +14,11 @@
       <% if user_signed_in? %>
       <strong><%= current_user.name %></strong><%= t("Logged in as") %>
       <%= link_to t("Profile"), user_path(id: current_user.id), class: 'navbar-link' %> |
-      <%= link_to t("Edit profile"), edit_user_registration_path, class: 'navbar-link' %> |
-      <%= link_to t("Logout"), destroy_user_session_path, method: :delete, class: 'navbar-link'  %>
+      <%= link_to t("All users"), users_path %> |
+      <%= link_to t("Logout"), destroy_user_session_path, method: :delete, class: 'navbar-link' %>
       <% else %>
-      <%= link_to t("Sign up"), new_user_registration_path, class: 'navbar-link'  %> |
-      <%= link_to t("Login"), new_user_session_path, class: 'navbar-link'  %>
+      <%= link_to t("Sign up"), new_user_registration_path, class: 'navbar-link' %> |
+      <%= link_to t("Login"), new_user_session_path, class: 'navbar-link' %>
       <% end %>
     </p>
     <% if notice %>

--- a/app/views/users/_follow.html.erb
+++ b/app/views/users/_follow.html.erb
@@ -1,4 +1,4 @@
 <%= form_with model: current_user.active_follows.build do |f| %>
   <div><%= hidden_field_tag :followed_id, @user.id %></div>
-  <%= f.submit "フォローする", class: "btn" %>
+  <%= f.submit t("Follow"), class: "btn" %>
 <% end %>

--- a/app/views/users/_follow.html.erb
+++ b/app/views/users/_follow.html.erb
@@ -1,0 +1,4 @@
+<%= form_with model: current_user.active_follows.build do |f| %>
+  <div><%= hidden_field_tag :followed_id, @user.id %></div>
+  <%= f.submit "フォローする", class: "btn" %>
+<% end %>

--- a/app/views/users/_follow_form.html.erb
+++ b/app/views/users/_follow_form.html.erb
@@ -1,0 +1,9 @@
+<div class="follow-form">
+  <% if current_user.id != @user.id %>
+    <% if current_user.following?(@user) %>
+      <%= render "unfollow" %>
+    <% else %>
+      <%= render "follow" %>
+    <% end %>
+  <% end %>
+</div>

--- a/app/views/users/_unfollow.html.erb
+++ b/app/views/users/_unfollow.html.erb
@@ -1,0 +1,4 @@
+<%= form_with model: current_user.active_follows.find_by(followed_id: @user.id),
+            html: { method: :delete } do |f| %>
+<%= f.submit "フォロー解除", class: "btn" %>
+<% end %>

--- a/app/views/users/_unfollow.html.erb
+++ b/app/views/users/_unfollow.html.erb
@@ -1,4 +1,4 @@
 <%= form_with model: current_user.active_follows.find_by(followed_id: @user.id),
             html: { method: :delete } do |f| %>
-<%= f.submit "フォロー解除", class: "btn" %>
+<%= f.submit t("Unfollow"), class: "btn" %>
 <% end %>

--- a/app/views/users/followers/index.html.erb
+++ b/app/views/users/followers/index.html.erb
@@ -1,0 +1,21 @@
+<h2><%= t("followers.index.title", user: @user.name) %></h2>
+
+<table>
+  <thead>
+    <tr>
+      <th><%= User.human_attribute_name(:name) %></th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @users.each do |user| %>
+    <tr>
+      <td><%= link_to user.name, user_path(user) %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= link_to t("link.Back"), user_path(@user) %>
+<%= link_to t("link.Top"), root_path %>

--- a/app/views/users/followings/index.html.erb
+++ b/app/views/users/followings/index.html.erb
@@ -1,0 +1,21 @@
+<h2><%= t("followings.index.title", user: @user.name) %></h2>
+
+<table>
+  <thead>
+    <tr>
+      <th><%= User.human_attribute_name(:name) %></th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @users.each do |user| %>
+    <tr>
+      <td><%= link_to user.name, user_path(user) %></td>
+    </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= link_to t("link.Back"), user_path(@user) %>
+<%= link_to t("link.Top"), root_path %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -6,4 +6,5 @@
     </li>
     <% end %>
   </ul>
-<%= link_to t("link.Back"), root_path %>
+
+<%= link_to t("link.Top"), root_path %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,9 @@
+<h1><%= t("users.index.title") %></h1>
+  <ul class="users">
+    <% @users.each do |user| %>
+    <li>
+      <%= link_to user.name, user %>
+    </li>
+    <% end %>
+  </ul>
+<%= link_to t("link.Back"), root_path %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,6 +23,9 @@
   <%= @user.introduction %>
 </p>
 
-<%= render 'follow_form' %>
+<%= render "follow_form" %>
+<% if current_user == @user %>
+  <%= link_to t("Edit profile"), edit_user_registration_path %>
+<% end %>
 
 <%= link_to t("link.Back"), root_path %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -7,6 +7,13 @@
 <%= image_tag(@user.avatar.variant(resize_to_fit: [150, 150])) %>
 <% end %>
 <p>
+  <%= link_to t("users.show.follow"), user_followings_path(@user) %> <%= @user.following.count %> |
+  <%= link_to t("users.show.follower"), user_followers_path(@user) %> <%= @user.followers.count %>
+</p>
+
+<%= render "follow_form" %>
+
+<p>
   <strong><%= User.human_attribute_name(:email) + ":" %></strong>
   <%= @user.email %>
 </p>
@@ -23,7 +30,6 @@
   <%= @user.introduction %>
 </p>
 
-<%= render "follow_form" %>
 <% if current_user == @user %>
   <%= link_to t("Edit profile"), edit_user_registration_path %>
 <% end %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -23,5 +23,6 @@
   <%= @user.introduction %>
 </p>
 
+<%= render 'follow_form' %>
 
 <%= link_to t("link.Back"), root_path %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,5 +10,6 @@ module BooksApp
     config.load_defaults 6.0
     config.i18n.default_locale = :ja
     config.i18n.load_path += Dir[Rails.root.join("config", "locales", "**", "*.{rb,yml}").to_s]
+    config.action_view.embed_authenticity_token_in_remote_forms = true
   end
 end

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -1,5 +1,7 @@
 ja:
   users:
+    index:
+      title: ユーザー一覧
     show:
       title: プロフィール
     update:
@@ -19,3 +21,4 @@ ja:
   Sign up: アカウント登録
   Login: ログイン
   Log in: ログイン
+  All users: ユーザー一覧

--- a/config/locales/devise.views.ja.yml
+++ b/config/locales/devise.views.ja.yml
@@ -4,6 +4,8 @@ ja:
       title: ユーザー一覧
     show:
       title: プロフィール
+      follow: フォロー
+      follower: フォロワー
     update:
       title: プロフィールの編集
   activerecord:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,7 +19,8 @@ ja:
         picture: 画像
   link:
     New Book: 新規作成
-    Back: トップに戻る
+    Top: トップ
+    Back: 戻る
     Show: 詳細
     Edit: 編集
     Destroy: 削除 
@@ -29,6 +30,12 @@ ja:
     destroy: "本が削除されました"
   alert:
     sure: "本当によろしいですか？"
+  followings: 
+    index:
+      title: "%{user}のフォロー"
+  followers: 
+    index:
+      title: "%{user}のフォロワー"
   Follow: フォローする
   Unfollow: フォロー解除
   Books: 本

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,6 +11,7 @@ ja:
       book: 本
     attributes:
       book:
+        user_name: 投稿者
         title: タイトル
         memo: メモ
         created_at: 作成日時

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -19,16 +19,18 @@ ja:
         picture: 画像
   link:
     New Book: 新規作成
-    Back: 戻る
+    Back: トップに戻る
     Show: 詳細
     Edit: 編集
-    Destroy: 削除
+    Destroy: 削除 
   flash:
     create: "本が保存されました"
     update: "本が更新されました"
     destroy: "本が削除されました"
   alert:
     sure: "本当によろしいですか？"
+  Follow: フォローする
+  Unfollow: フォロー解除
   Books: 本
   New Book: 新規作成
   Editing Book: 編集

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  get "users/show"
   devise_for :users, controllers: {
         registrations: "users/registrations",
         omniauth_callbacks: "users/omniauth_callbacks"
@@ -14,6 +13,6 @@ Rails.application.routes.draw do
 
   resources :follows, only: [:create, :destroy]
   resources :books
-  resources :users, only: [:show]
+  resources :users, only: [:index, :show]
   root to: "books#index"
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,13 @@ Rails.application.routes.draw do
         registrations: "users/registrations",
         omniauth_callbacks: "users/omniauth_callbacks"
   }
+
+  resources :users do
+    resources :followings, only: :index, controller: "users/followings"
+    resources :followers, only: :index, controller: "users/followers"
+  end
+
+  resources :follows, only: [:create, :destroy]
   resources :books
   resources :users, only: [:show]
   root to: "books#index"

--- a/db/migrate/20200717121328_add_user_id_to_books.rb
+++ b/db/migrate/20200717121328_add_user_id_to_books.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddUserIdToBooks < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :books, :user, foreign_key: true
+  end
+end

--- a/db/migrate/20200724123433_create_follows.rb
+++ b/db/migrate/20200724123433_create_follows.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class CreateFollows < ActiveRecord::Migration[6.0]
+  def change
+    create_table :follows do |t|
+      t.integer :follower_id
+      t.integer :followed_id
+
+      t.timestamps
+    end
+    add_index :follows, :follower_id
+    add_index :follows, :followed_id
+    add_index :follows, [:follower_id, :followed_id], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,8 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_17_121328) do
-
+ActiveRecord::Schema.define(version: 2020_07_24_123433) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -41,6 +42,16 @@ ActiveRecord::Schema.define(version: 2020_07_17_121328) do
     t.string "picture"
     t.integer "user_id"
     t.index ["user_id"], name: "index_books_on_user_id"
+  end
+
+  create_table "follows", force: :cascade do |t|
+    t.integer "follower_id"
+    t.integer "followed_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["followed_id"], name: "index_follows_on_followed_id"
+    t.index ["follower_id", "followed_id"], name: "index_follows_on_follower_id_and_followed_id", unique: true
+    t.index ["follower_id"], name: "index_follows_on_follower_id"
   end
 
   create_table "users", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -12,7 +10,8 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_16_130918) do
+ActiveRecord::Schema.define(version: 2020_07_17_121328) do
+
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
     t.string "record_type", null: false
@@ -40,6 +39,8 @@ ActiveRecord::Schema.define(version: 2020_07_16_130918) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.string "picture"
+    t.integer "user_id"
+    t.index ["user_id"], name: "index_books_on_user_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -62,4 +63,5 @@ ActiveRecord::Schema.define(version: 2020_07_16_130918) do
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
+  add_foreign_key "books", "users"
 end


### PR DESCRIPTION
# 概要
- UserモデルとBookモデルを1対多で関連付け
- Followモデルを作成し、Userモデルの多対多の関連付けをhmtで実装
- フォロー、フォロー解除ボタンをプロフィールページに実装。
- 全ユーザーリストのページを作成
- フォロー/フォロワー一覧のページを作成しプロフィールページにリンク作成
- 投稿している本の投稿者にのみ編集・削除ボタンが表示されるように変更
- トップの投稿一覧には自分と自分のフォローしているユーザーの本のみ表示するよう変更
- トップの投稿一覧の本の隣に投稿者の名前とリンクを作成
# 投稿一覧
![image](https://user-images.githubusercontent.com/56685224/88526118-7a7c4f80-d036-11ea-8f6a-c5b289cd3aa7.png)
# 自分のプロフィールページ
![image](https://user-images.githubusercontent.com/56685224/88526154-8831d500-d036-11ea-9e66-b208cf5d869a.png)
# 自分以外のユーザープロフィール
![image](https://user-images.githubusercontent.com/56685224/88526215-9ed82c00-d036-11ea-88d3-6736978dd5a3.png)
# フォロー/フォロワー一覧
## フォロー一覧
![image](https://user-images.githubusercontent.com/56685224/88526297-badbcd80-d036-11ea-826c-c619b52ca381.png)
## フォロワー一覧(0人)
![image](https://user-images.githubusercontent.com/56685224/88526317-c3cc9f00-d036-11ea-9534-49823d025053.png)
